### PR TITLE
ovsdb-monitor.at: Use correct perl scripts.

### DIFF
--- a/tests/ovsdb-monitor.at
+++ b/tests/ovsdb-monitor.at
@@ -630,7 +630,7 @@ AT_CHECK([ovsdb-client transact unix:socket '[["ordinals"]]'], [0],
          [ignore], [ignore])
 AT_CHECK([ovs-appctl -t ovsdb-server -e exit], [0], [ignore], [ignore])
 OVS_WAIT_UNTIL([test ! -e ovsdb-server.pid && test ! -e ovsdb-client.pid])
-AT_CHECK([$PYTHON $srcdir/ovsdb-monitor-sort.py < output | uuidfilt], [0], [[row,action,name
+AT_CHECK([${PERL} $srcdir/ovsdb-monitor-sort.pl < output | ${PERL} $srcdir/uuidfilt.pl], [0], [[row,action,name
 <0>,insert,"""ten"""
 
 row,action,name


### PR DESCRIPTION
Python scripts appeared only since OVS 2.9.
This fixes unit test 'monitor-cond-change with many sessions pending'.
Issue appered while backporting the following patch:
e0f42d4a6548 ("monitor: Fix crash when monitor condition adds new columns.")

Acked-by: Aaron Conole <aconole@redhat.com>
Acked-by: Han Zhou <hzhou8@ebay.com>
Signed-off-by: Ilya Maximets <i.maximets@samsung.com>
Signed-off-by: Ben Pfaff <blp@ovn.org>